### PR TITLE
Show episode labels in sidebar

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -41,6 +41,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     videosInfo,
     chartDataGroups,
     episodes,
+    episodeLabels,
     ignoredColumns,
   } = data;
 
@@ -160,6 +161,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
         datasetInfo={datasetInfo}
         paginatedEpisodes={paginatedEpisodes}
         episodeId={episodeId}
+        episodeLabels={episodeLabels}
         totalPages={totalPages}
         currentPage={currentPage}
         prevPage={prevPage}

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -50,6 +50,26 @@ export async function getEpisodeData(
       (_, i) => i + 1,
     );
 
+    // Fetch episode metadata to build labels
+    const episodesLabels: Record<number, string> = {};
+    try {
+      const episodesUrl = await getSignedS3Url("meta/episodes.jsonl");
+      const text = await (await fetch(episodesUrl)).text();
+      const episodesData = text
+        .split("\n")
+        .filter((line) => line.trim().length)
+        .map((line) => JSON.parse(line));
+      for (const ep of episodesData) {
+        const epNum = Number(ep.episode_index) + 1;
+        const labelPath = Array.isArray(ep.input_key)
+          ? ep.input_key[1].split("/").slice(-5).join("/")
+          : "";
+        episodesLabels[epNum] = `${epNum}: ${labelPath}`;
+      }
+    } catch (err) {
+      console.warn("Failed to fetch episodes.jsonl", err);
+    }
+
     // Videos information
     const videosInfo = Object.entries(info.features)
       .filter(([key, value]) => value.dtype === "video")
@@ -218,6 +238,7 @@ export async function getEpisodeData(
       videosInfo: resolvedVideosInfo,
       chartDataGroups,
       episodes,
+      episodeLabels: episodesLabels,
       ignoredColumns,
       duration,
     };

--- a/lerobot/html_dataset_visualizer/src/components/side-nav.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/side-nav.tsx
@@ -7,6 +7,7 @@ interface SidebarProps {
   datasetInfo: any;
   paginatedEpisodes: any[];
   episodeId: any;
+  episodeLabels: Record<number, string>;
   totalPages: number;
   currentPage: number;
   prevPage: () => void;
@@ -17,6 +18,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   datasetInfo,
   paginatedEpisodes,
   episodeId,
+  episodeLabels,
   totalPages,
   currentPage,
   prevPage,
@@ -70,7 +72,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                   href={`./episode_${episode}`}
                   className={`underline ${episode === episodeId ? "-ml-1 font-bold" : ""}`}
                 >
-                  Episode {episode}
+                  {episodeLabels[episode] ?? `Episode ${episode}`}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- fetch episode metadata from `episodes.jsonl`
- pass episode labels to EpisodeViewer and Sidebar
- display label in sidebar instead of plain episode number

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest` *(fails: `ModuleNotFoundError: No module named 'serial'`)*

------
https://chatgpt.com/codex/tasks/task_e_6849954187a8832a8621df2d55243c09