### PR TITLE
Display episode tasks

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -41,6 +41,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     videosInfo,
     chartDataGroups,
     episodes,
+    tasks,
     ignoredColumns,
   } = data;
 
@@ -205,6 +206,12 @@ function EpisodeViewerInner({ data }: { data: any }) {
             videosInfo={videosInfo}
             onVideosReady={() => setVideosReady(true)}
           />
+        )}
+
+        {tasks && tasks.length > 0 && (
+          <p className="font-medium mt-2">
+            Tasks: <span className="italic">{tasks.join(", ")}</span>
+          </p>
         )}
 
         {/* Graph */}

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -50,6 +50,20 @@ export async function getEpisodeData(
       (_, i) => i + 1,
     );
 
+    // Load tasks from episodes.jsonl
+    const episodesUrl = await getSignedS3Url("meta/episodes.jsonl");
+    const episodesRes = await fetch(episodesUrl);
+    const episodesText = await episodesRes.text();
+    let tasks: string[] = [];
+    for (const line of episodesText.split("\n")) {
+      if (!line.trim()) continue;
+      const obj = JSON.parse(line);
+      if (obj.episode_index === episodeId) {
+        tasks = obj.tasks ?? [];
+        break;
+      }
+    }
+
     // Videos information
     const videosInfo = Object.entries(info.features)
       .filter(([key, value]) => value.dtype === "video")
@@ -218,6 +232,7 @@ export async function getEpisodeData(
       videosInfo: resolvedVideosInfo,
       chartDataGroups,
       episodes,
+      tasks,
       ignoredColumns,
       duration,
     };


### PR DESCRIPTION
## Summary
- load episode tasks from `episodes.jsonl`
- return tasks with other episode data
- render tasks below the video player

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68499597a2f4832a830ee344ecf12bf7