### PR TITLE
Display tasks in episode viewer

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -42,6 +42,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     chartDataGroups,
     episodes,
     episodeLabels,
+    tasks,
     ignoredColumns,
   } = data;
 
@@ -198,6 +199,11 @@ function EpisodeViewerInner({ data }: { data: any }) {
             <p className="font-mono text-lg font-semibold">
               episode {episodeId}
             </p>
+            {tasks?.length > 0 && (
+              <p className="text-sm">
+                tasks: <span className="font-mono">{tasks.join(", ")}</span>
+              </p>
+            )}
           </div>
         </div>
 

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -50,8 +50,9 @@ export async function getEpisodeData(
       (_, i) => i + 1,
     );
 
-    // Fetch episode metadata to build labels
+    // Fetch episode metadata to build labels and tasks
     const episodesLabels: Record<number, string> = {};
+    const episodesTasks: Record<number, string[]> = {};
     try {
       const episodesUrl = await getSignedS3Url("meta/episodes.jsonl");
       const text = await (await fetch(episodesUrl)).text();
@@ -65,6 +66,7 @@ export async function getEpisodeData(
           ? ep.input_key[1].split("/").slice(-5).join("/")
           : "";
         episodesLabels[epNum] = `${epNum}: ${labelPath}`;
+        episodesTasks[epNum] = Array.isArray(ep.tasks) ? ep.tasks : [];
       }
     } catch (err) {
       console.warn("Failed to fetch episodes.jsonl", err);
@@ -239,6 +241,7 @@ export async function getEpisodeData(
       chartDataGroups,
       episodes,
       episodeLabels: episodesLabels,
+      tasks: episodesTasks[episodeId + 1] ?? [],
       ignoredColumns,
       duration,
     };


### PR DESCRIPTION
## Summary
- load task list from `episodes.jsonl`
- return episode tasks from the data fetcher
- show tasks under the episode header in the HTML visualizer

## Testing
- `pre-commit run --files lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a1864720832a91c06fc563f93d50