### PR TITLE
Improve dataset names on viewer

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -193,7 +193,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
               href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
               target="_blank"
             >
-              <p className="text-lg font-semibold">{datasetInfo.repoId}</p>
+              <p className="text-lg font-semibold">{datasetInfo.displayName}</p>
             </a>
 
             <p className="font-mono text-lg font-semibold">

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -5,6 +5,7 @@ import {
   formatStringWithVars,
   readParquetColumn,
 } from "@/utils/parquetUtils";
+import { getDatasetDisplayName } from "@/utils/datasetUtils";
 import { pick } from "@/utils/pick";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
@@ -20,12 +21,16 @@ export async function getEpisodeData(
   episodeId: number,
 ) {
   const repoId = `${org}/${dataset}`.replace(/~/g, "/");
+  const displayName = getDatasetDisplayName(repoId);
   const [bucket, ...prefixParts] = repoId.split("/");
   const keyPrefix = prefixParts.join("/").replace(/\/$/, "");
   const s3Client = new S3Client({ region: "us-east-2" });
 
   const getSignedS3Url = async (key: string) => {
-    const command = new GetObjectCommand({ Bucket: bucket, Key: `${keyPrefix}/${key}` });
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: `${keyPrefix}/${key}`,
+    });
     return getSignedUrl(s3Client, command, { expiresIn: 3600 });
   };
 
@@ -38,6 +43,7 @@ export async function getEpisodeData(
     // Dataset information
     const datasetInfo = {
       repoId,
+      displayName,
       total_frames: info.total_frames,
       total_episodes: info.total_episodes,
       fps: info.fps,

--- a/lerobot/html_dataset_visualizer/src/app/explore/explore-grid.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/explore-grid.tsx
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { postParentMessageWithParams } from "@/utils/postParentMessage";
 
 type ExploreGridProps = {
-  datasets: Array<{ id: string; videoUrl: string | null }>;
+  datasets: Array<{ id: string; displayName: string; videoUrl: string | null }>;
   currentPage: number;
   totalPages: number;
 };
@@ -68,7 +68,7 @@ export default function ExploreGrid({
             />
             <div className="absolute top-0 left-0 w-full h-full bg-black/40 z-10 pointer-events-none" />
             <div className="relative z-20 font-mono text-blue-100 break-all text-sm bg-black/60 backdrop-blur px-2 py-1 rounded shadow">
-              {ds.id}
+              {ds.displayName}
             </div>
           </Link>
         ))}

--- a/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
@@ -5,9 +5,14 @@ import {
   fetchJson,
   formatStringWithVars,
 } from "@/utils/parquetUtils";
+import { getDatasetDisplayName } from "@/utils/datasetUtils";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
-import { S3Client, HeadObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  HeadObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 // Server component for data fetching
@@ -31,11 +36,10 @@ export default async function ExplorePage({
       }),
     );
 
-    const builderDatasets: string[] =
-      (scanBuilder.Items || []).map(
-        (item: { version: string; data_name: string }) =>
-          `configint/data-builder/${item.version}/data/${item.data_name}/`,
-      );
+    const builderDatasets: string[] = (scanBuilder.Items || []).map(
+      (item: { version: string; data_name: string }) =>
+        `configint/data-builder/${item.version}/data/${item.data_name}/`,
+    );
 
     const scanVisualizer = await docClient.send(
       new ScanCommand({
@@ -44,10 +48,9 @@ export default async function ExplorePage({
       }),
     );
 
-    const visualizerDatasets: string[] =
-      (scanVisualizer.Items || []).map(
-        (item: { s3_dir: string }) => item.s3_dir,
-      );
+    const visualizerDatasets: string[] = (scanVisualizer.Items || []).map(
+      (item: { s3_dir: string }) => item.s3_dir,
+    );
 
     const allDatasets = [...builderDatasets, ...visualizerDatasets];
 
@@ -73,9 +76,10 @@ export default async function ExplorePage({
       datasets.map(async (s3Dir: string) => {
         try {
           // Parse S3 URI (e.g. s3://my-bucket/path/to/dataset)
-          const [bucket, ...keyParts] = s3Dir.split('/');
-          const repoId = `${bucket}/${keyParts.join('~')}`;
-          const keyPrefix = keyParts.join('/').replace(/\/$/, '');
+          const [bucket, ...keyParts] = s3Dir.split("/");
+          const repoId = `${bucket}/${keyParts.join("~")}`;
+          const displayName = getDatasetDisplayName(repoId);
+          const keyPrefix = keyParts.join("/").replace(/\/$/, "");
 
           // ------- meta/info.json -------
           const infoKey = `${keyPrefix}/meta/info.json`;
@@ -120,14 +124,21 @@ export default async function ExplorePage({
             }
           }
 
-          return videoUrl ? { id: repoId, videoUrl } : null;
+          return videoUrl ? { id: repoId, displayName, videoUrl } : null;
         } catch (err) {
-          console.error(`Failed to fetch or parse dataset info for ${s3Dir}:`, err);
+          console.error(
+            `Failed to fetch or parse dataset info for ${s3Dir}:`,
+            err,
+          );
           return null;
         }
       }),
     )
-  ).filter(Boolean) as { id: string; videoUrl: string | null }[];
+  ).filter(Boolean) as {
+    id: string;
+    displayName: string;
+    videoUrl: string | null;
+  }[];
 
   return (
     <ExploreGrid

--- a/lerobot/html_dataset_visualizer/src/utils/datasetUtils.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/datasetUtils.ts
@@ -1,0 +1,11 @@
+export function getDatasetDisplayName(repoId: string): string {
+  const path = repoId.replace(/~/g, "/");
+  const match = path.match(
+    /^configint\/data-builder\/([^/]+)\/data\/([^/]+)\/?$/,
+  );
+  if (match) {
+    return `${match[1]}/${match[2]}`;
+  }
+  // fallback: remove trailing tilde and show as-is replacing ~ with /
+  return repoId.replace(/~/g, "/");
+}


### PR DESCRIPTION
## Summary
- show nicer dataset names in Explore and Episode pages
- compute displayName property for dataset paths

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run format`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6849a379bd28832a82ab75771b9292e9