### PR TITLE
Update visualizer layout

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -169,70 +169,73 @@ function EpisodeViewerInner({ data }: { data: any }) {
         nextPage={nextPage}
       />
 
-      {/* Content */}
-      <div
-        className={`flex max-h-screen flex-col gap-4 p-4 md:flex-1 relative ${isLoading ? "overflow-hidden" : "overflow-y-auto"}`}
-      >
-        {isLoading && <Loading />}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Videos column */}
+        <div
+          className={`flex w-1/2 flex-col gap-4 p-4 relative ${isLoading ? "overflow-hidden" : "overflow-y-auto"}`}
+        >
+          {isLoading && <Loading />}
 
-        <div className="flex items-center justify-start my-4">
-          <a
-            href="https://github.com/huggingface/lerobot"
-            target="_blank"
-            className="block"
-          >
-            <img
-              src="https://github.com/huggingface/lerobot/raw/main/media/lerobot-logo-thumbnail.png"
-              alt="LeRobot Logo"
-              className="w-32"
-            />
-          </a>
-
-          <div>
+          <div className="flex items-center justify-start my-4">
             <a
-              href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
+              href="https://github.com/huggingface/lerobot"
               target="_blank"
+              className="block"
             >
-              <p className="text-lg font-semibold">{datasetInfo.repoId}</p>
+              <img
+                src="https://github.com/huggingface/lerobot/raw/main/media/lerobot-logo-thumbnail.png"
+                alt="LeRobot Logo"
+                className="w-32"
+              />
             </a>
 
-            <p className="font-mono text-lg font-semibold">
-              episode {episodeId}
-            </p>
-            {tasks?.length > 0 && (
-              <p className="text-sm">
-                tasks: <span className="font-mono">{tasks.join(", ")}</span>
+            <div>
+              <a
+                href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
+                target="_blank"
+              >
+                <p className="text-lg font-semibold">{datasetInfo.repoId}</p>
+              </a>
+
+              <p className="font-mono text-lg font-semibold">
+                episode {episodeId}
+              </p>
+              {tasks?.length > 0 && (
+                <p className="text-sm">
+                  tasks: <span className="font-mono">{tasks.join(", ")}</span>
+                </p>
+              )}
+            </div>
+          </div>
+
+          {videosInfo.length && (
+            <VideosPlayer
+              videosInfo={videosInfo}
+              onVideosReady={() => setVideosReady(true)}
+            />
+          )}
+
+          <PlaybackBar />
+        </div>
+
+        {/* Charts column */}
+        <div className="flex w-1/2 flex-col p-4 overflow-y-auto">
+          <div className="mb-4">
+            <DataRecharts
+              data={chartDataGroups}
+              onChartsReady={() => setChartsReady(true)}
+            />
+
+            {ignoredColumns.length > 0 && (
+              <p className="mt-2 text-orange-700">
+                Columns{" "}
+                <span className="font-mono">{ignoredColumns.join(", ")}</span>{" "}
+                are NOT shown since the visualizer currently does not support 2D
+                or 3D data.
               </p>
             )}
           </div>
         </div>
-
-        {/* Videos */}
-        {videosInfo.length && (
-          <VideosPlayer
-            videosInfo={videosInfo}
-            onVideosReady={() => setVideosReady(true)}
-          />
-        )}
-
-        {/* Graph */}
-        <div className="mb-4">
-          <DataRecharts
-            data={chartDataGroups}
-            onChartsReady={() => setChartsReady(true)}
-          />
-
-          {ignoredColumns.length > 0 && (
-            <p className="mt-2 text-orange-700">
-              Columns{" "}
-              <span className="font-mono">{ignoredColumns.join(", ")}</span> are
-              NOT shown since the visualizer currently does not support 2D or 3D
-              data.
-            </p>
-          )}
-        </div>
-
-        <PlaybackBar />
       </div>
     </div>
   );

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -33,9 +33,9 @@ export const DataRecharts = React.memo(
     }, [onChartsReady]);
 
     return (
-      <div className="flex gap-4 overflow-x-auto pb-4">
+      <div className="flex flex-col gap-4 overflow-y-auto pr-4">
         {data.map((group, idx) => (
-          <div key={idx} className="flex-shrink-0 min-w-[28rem]">
+          <div key={idx} className="flex-shrink-0 w-full">
             <SingleDataGraph
               data={group}
               hoveredTime={hoveredTime}
@@ -145,8 +145,8 @@ const SingleDataGraph = React.memo(
     };
 
     return (
-      <div className="w-full">
-        <div className="w-full h-80" onMouseLeave={handleMouseLeave}>
+      <div className="flex w-full">
+        <div className="flex-1 h-80" onMouseLeave={handleMouseLeave}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}
@@ -221,7 +221,9 @@ const SingleDataGraph = React.memo(
             </LineChart>
           </ResponsiveContainer>
         </div>
-        <CustomLegend />
+        <div className="ml-4">
+          <CustomLegend />
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
## Summary
- change chart container to vertical layout
- move legend to the right of each chart
- rearrange episode viewer so videos scroll vertically next to charts

## Testing
- `npm run format`
- `pytest` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6849ac464d6c832a94da1353e9e7a2b3