### PR TITLE
Update html visualizer chart and layout

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -40,6 +40,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     episodeId,
     videosInfo,
     chartData,
+    columns,
     episodes,
     episodeLabels,
     tasks,
@@ -233,6 +234,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
           <div className="w-full max-w-full">
             <DataRecharts
               data={chartData}
+              columns={columns}
               onChartsReady={() => setChartsReady(true)}
             />
 

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -235,6 +235,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
             <DataRecharts
               data={chartData}
               columns={columns}
+              datasetId={datasetInfo.repoId}
               onChartsReady={() => setChartsReady(true)}
             />
 

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -39,7 +39,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     datasetInfo,
     episodeId,
     videosInfo,
-    chartDataGroups,
+    chartData,
     episodes,
     episodeLabels,
     tasks,
@@ -180,7 +180,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
       <div className="flex flex-1 overflow-hidden">
         {/* Videos column */}
         <div
-          className={`flex w-[40%] flex-col gap-4 p-4 relative ${isLoading ? "overflow-hidden" : "overflow-y-auto"}`}
+          className={`flex w-[50%] flex-col gap-4 p-4 relative ${isLoading ? "overflow-hidden" : "overflow-y-auto"}`}
         >
           {isLoading && <Loading />}
 
@@ -229,10 +229,10 @@ function EpisodeViewerInner({ data }: { data: any }) {
         </div>
 
         {/* Charts column */}
-        <div className="flex w-[60%] flex-col p-4 overflow-y-auto">
+        <div className="flex w-[50%] flex-col p-4 overflow-y-auto">
           <div className="mb-4">
             <DataRecharts
-              data={chartDataGroups}
+              data={chartData}
               onChartsReady={() => setChartsReady(true)}
             />
 

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -229,8 +229,8 @@ function EpisodeViewerInner({ data }: { data: any }) {
         </div>
 
         {/* Charts column */}
-        <div className="flex w-[50%] flex-col p-4 overflow-y-auto">
-          <div className="mb-4">
+        <div className="flex w-[50%] flex-col p-4 items-center justify-center">
+          <div className="w-full max-w-full">
             <DataRecharts
               data={chartData}
               onChartsReady={() => setChartsReady(true)}

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -166,34 +166,13 @@ export async function getEpisodeData(
       )
       .map(([key]) => key);
 
-    // --- Group columns by their base names ---
-    // Each top-level feature becomes a chart. If a feature has multiple
-    // sub-values (e.g. an array), all of those series are shown on the same
-    // chart.
-    const chartGroups = columns
-      .map(({ value }) =>
-        value.length > 6
-          ? value.reduce<string[][]>((acc, name, idx) => {
-              const groupIdx = Math.floor(idx / 6);
-              if (!acc[groupIdx]) acc[groupIdx] = [];
-              acc[groupIdx].push(name);
-              return acc;
-            }, [])
-          : [value],
-      )
-      .flat();
-
     const duration = chartData[chartData.length - 1].timestamp;
-
-    const chartDataGroups = chartGroups.map((group) =>
-      chartData.map((row) => pick(row, [...group, "timestamp"])),
-    );
 
     return {
       datasetInfo,
       episodeId: episodeId + 1,
       videosInfo: resolvedVideosInfo,
-      chartDataGroups,
+      chartData,
       episodes,
       episodeLabels: episodesLabels,
       tasks: episodesTasks[episodeId + 1] ?? [],

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -173,6 +173,7 @@ export async function getEpisodeData(
       episodeId: episodeId + 1,
       videosInfo: resolvedVideosInfo,
       chartData,
+      columns,
       episodes,
       episodeLabels: episodesLabels,
       tasks: episodesTasks[episodeId + 1] ?? [],

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -199,6 +199,7 @@ const SingleDataGraph = React.memo(
       );
     };
     return (
+      <div>
         <div className="h-80" onMouseLeave={handleMouseLeave}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -88,6 +88,23 @@ const SingleDataGraph = React.memo(
     return [];
   });
 
+  const colorMap = useMemo(() => {
+    const keys = visibleKeys.length > 0 ? visibleKeys : dataKeys;
+    const map: Record<string, string> = {};
+    keys.forEach((k, i) => {
+      const hue = (i * 360) / keys.length;
+      map[k] = `hsl(${hue}, 100%, 50%)`;
+    });
+    // fallback colors for non-visible keys
+    dataKeys.forEach((k, i) => {
+      if (!(k in map)) {
+        const hue = (i * 360) / dataKeys.length;
+        map[k] = `hsl(${hue}, 100%, 50%)`;
+      }
+    });
+    return map;
+  }, [visibleKeys, dataKeys]);
+
   const toggleAll = () => {
     setVisibleKeys((prev) =>
       prev.length === dataKeys.length ? [] : [...dataKeys],
@@ -177,6 +194,7 @@ const SingleDataGraph = React.memo(
                           className="size-3.5"
                           checked={allChecked}
                           onChange={() => handleColumnToggle(col)}
+                          style={{ accentColor: colorMap[col.value[0]] }}
                         />
                         <span>{col.key}</span>
                       </label>
@@ -193,6 +211,7 @@ const SingleDataGraph = React.memo(
                               className="size-3.5"
                               checked={isChecked}
                               onChange={() => handleCheckboxChange(key)}
+                              style={{ accentColor: colorMap[key] }}
                             />
                           </label>
                         </td>
@@ -265,14 +284,14 @@ const SingleDataGraph = React.memo(
 
               {/* Render lines for visible dataKeys only */}
               {dataKeys.map(
-                (key, index) =>
+                (key) =>
                   visibleKeys.includes(key) && (
                     <Line
                       key={key}
                       type="monotone"
                       dataKey={key}
                       name={key}
-                      stroke={`hsl(${index * (360 / dataKeys.length)}, 100%, 50%)`}
+                      stroke={colorMap[key]}
                       dot={false}
                       activeDot={false}
                       strokeWidth={1.5}

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -73,8 +73,20 @@ const SingleDataGraph = React.memo(
     const { currentTime, setCurrentTime } = useTime();
   const chartData = useMemo(() => data, [data]);
   const [dataKeys, setDataKeys] = useState<string[]>([]);
-  const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
   const storageKey = `visibleKeys:${datasetId}`;
+  const [visibleKeys, setVisibleKeys] = useState<string[]>(() => {
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        try {
+          return JSON.parse(saved) as string[];
+        } catch {
+          return [];
+        }
+      }
+    }
+    return [];
+  });
 
   const toggleAll = () => {
     setVisibleKeys((prev) =>
@@ -82,25 +94,12 @@ const SingleDataGraph = React.memo(
     );
   };
 
-    useEffect(() => {
-      if (!data || data.length === 0) return;
-      const keys = Object.keys(data[0]).filter((k) => k !== "timestamp");
-      setDataKeys(keys);
-      const saved =
-        typeof window !== "undefined"
-          ? localStorage.getItem(storageKey)
-          : null;
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved) as string[];
-          setVisibleKeys(parsed.filter((k) => keys.includes(k)));
-        } catch {
-          setVisibleKeys([]);
-        }
-      } else {
-        setVisibleKeys([]);
-      }
-    }, [data, storageKey]);
+  useEffect(() => {
+    if (!data || data.length === 0) return;
+    const keys = Object.keys(data[0]).filter((k) => k !== "timestamp");
+    setDataKeys(keys);
+    setVisibleKeys((prev) => prev.filter((k) => keys.includes(k)));
+  }, [data]);
 
     useEffect(() => {
       if (typeof window === "undefined") return;
@@ -184,17 +183,18 @@ const SingleDataGraph = React.memo(
                     </td>
                     {Array.from({ length: maxIndices }).map((_, idx) => {
                       const key = col.value[idx];
-                      if (!key)
-                        return <td key={idx} className="px-2" />;
+                      if (!key) return <td key={idx} className="px-2" />;
                       const isChecked = visibleKeys.includes(key);
                       return (
                         <td key={idx} className="px-2 text-center">
-                          <input
-                            type="checkbox"
-                            className="size-3.5"
-                            checked={isChecked}
-                            onChange={() => handleCheckboxChange(key)}
-                          />
+                          <label className="flex justify-center cursor-pointer">
+                            <input
+                              type="checkbox"
+                              className="size-3.5"
+                              checked={isChecked}
+                              onChange={() => handleCheckboxChange(key)}
+                            />
+                          </label>
                         </td>
                       );
                     })}

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -12,15 +12,23 @@ import {
   Tooltip,
 } from "recharts";
 
+const SERIES_NAME_DELIMITER = " | ";
+
+type ColumnGroup = {
+  key: string;
+  value: string[];
+};
+
 type DataGraphProps = {
   data: Array<Record<string, number>>;
+  columns: ColumnGroup[];
   onChartsReady?: () => void;
 };
 
 import React, { useMemo } from "react";
 
 export const DataRecharts = React.memo(
-  ({ data, onChartsReady }: DataGraphProps) => {
+  ({ data, columns, onChartsReady }: DataGraphProps) => {
     // Shared hoveredTime for all graphs
     const [hoveredTime, setHoveredTime] = useState<number | null>(null);
 
@@ -36,6 +44,7 @@ export const DataRecharts = React.memo(
       <div className="flex flex-col gap-4 overflow-y-auto pr-4">
         <SingleDataGraph
           data={data}
+          columns={columns}
           hoveredTime={hoveredTime}
           setHoveredTime={setHoveredTime}
         />
@@ -48,10 +57,12 @@ export const DataRecharts = React.memo(
 const SingleDataGraph = React.memo(
   ({
     data,
+    columns,
     hoveredTime,
     setHoveredTime,
   }: {
     data: Array<Record<string, number>>;
+    columns: ColumnGroup[];
     hoveredTime: number | null;
     setHoveredTime: (t: number | null) => void;
   }) => {
@@ -114,9 +125,9 @@ const SingleDataGraph = React.memo(
       }
     };
 
+
     // Custom legend to show current value next to each series
     const CustomLegend = () => {
-      // Find the closest data point to the hovered or current time
       const closestIndex = findClosestDataIndex(
         hoveredTime != null ? hoveredTime : currentTime,
       );
@@ -128,52 +139,66 @@ const SingleDataGraph = React.memo(
         );
       };
 
+      const handleColumnToggle = (col: ColumnGroup) => {
+        const allVisible = col.value.every((k) => visibleKeys.includes(k));
+        setVisibleKeys((prev) => {
+          if (allVisible) {
+            return prev.filter((k) => !col.value.includes(k));
+          }
+          return Array.from(new Set([...prev, ...col.value]));
+        });
+      };
+
+      const colorMap = useMemo(() => {
+        const map = new Map<string, string>();
+        dataKeys.forEach((k, idx) => {
+          map.set(k, `hsl(${(idx * 360) / dataKeys.length}, 100%, 50%)`);
+        });
+        return map;
+      }, [dataKeys]);
+
       return (
-        <div className="grid grid-cols-[repeat(auto-fit,250px)] gap-4 mx-8">
-          {dataKeys.map((key, idx) => {
-            const color = `hsl(${idx * (360 / dataKeys.length)}, 100%, 50%)`;
-            const isChecked = visibleKeys.includes(key);
+        <div className="flex flex-col gap-3 mx-4">
+          {columns.map((col) => {
+            const allChecked = col.value.every((k) => visibleKeys.includes(k));
             return (
-              <label
-                key={key}
-                className="flex gap-2 cursor-pointer select-none"
-              >
-                <input
-                  type="checkbox"
-                  checked={isChecked}
-                  onChange={() => handleCheckboxChange(key)}
-                  className="size-3.5 mt-1"
-                  style={{ accentColor: color }}
-                />
-                <span
-                  className={`text-sm break-all w-40 ${isChecked ? "text-white" : "text-gray-400"}`}
-                >
-                  {key}:
-                </span>
-                <span
-                  className={`text-sm font-mono ml-auto ${isChecked ? "text-orange-300" : "text-gray-500"}`}
-                >
-                  {typeof currentData[key] === "number"
-                    ? currentData[key].toFixed(2)
-                    : "--"}
-                </span>
-              </label>
+              <div key={col.key} className="flex items-start gap-4">
+                <label className="flex gap-2 w-36 select-none">
+                  <input
+                    type="checkbox"
+                    className="size-3.5 mt-1"
+                    checked={allChecked}
+                    onChange={() => handleColumnToggle(col)}
+                  />
+                  <span className="text-sm truncate">{col.key}</span>
+                </label>
+                <div className="flex flex-wrap gap-4">
+                  {col.value.map((key) => {
+                    const color = colorMap.get(key) || "#fff";
+                    const isChecked = visibleKeys.includes(key);
+                    const label = key.split(SERIES_NAME_DELIMITER)[1] || key;
+                    return (
+                      <label key={key} className="flex gap-1 cursor-pointer select-none">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => handleCheckboxChange(key)}
+                          className="size-3.5 mt-1"
+                          style={{ accentColor: color }}
+                        />
+                        <span className={`text-sm ${isChecked ? 'text-white' : 'text-gray-400'}`}>{label}</span>
+                        <span className={`text-sm font-mono ml-1 ${isChecked ? 'text-orange-300' : 'text-gray-500'}`}>{typeof currentData[key] === 'number' ? currentData[key].toFixed(2) : '--'}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
             );
           })}
         </div>
       );
     };
-
     return (
-      <div className="flex flex-col w-full">
-        <div className="flex justify-end mb-2">
-          <button
-            className="text-xs border border-slate-500 rounded px-2 py-1"
-            onClick={toggleAll}
-          >
-            {visibleKeys.length === dataKeys.length ? "Hide All Fields" : "Show All Fields"}
-          </button>
-        </div>
         <div className="h-80" onMouseLeave={handleMouseLeave}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
@@ -251,6 +276,14 @@ const SingleDataGraph = React.memo(
         </div>
         <div className="mt-4">
           <CustomLegend />
+        </div>
+        <div className="flex justify-end mt-2">
+          <button
+            className="text-xs border border-slate-500 rounded px-2 py-1"
+            onClick={toggleAll}
+          >
+            {visibleKeys.length === dataKeys.length ? "Hide All Fields" : "Show All Fields"}
+          </button>
         </div>
       </div>
     );

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 
 type DataGraphProps = {
-  data: Array<Array<Record<string, number>>>;
+  data: Array<Record<string, number>>;
   onChartsReady?: () => void;
 };
 
@@ -34,15 +34,11 @@ export const DataRecharts = React.memo(
 
     return (
       <div className="flex flex-col gap-4 overflow-y-auto pr-4">
-        {data.map((group, idx) => (
-          <div key={idx} className="flex-shrink-0 w-full">
-            <SingleDataGraph
-              data={group}
-              hoveredTime={hoveredTime}
-              setHoveredTime={setHoveredTime}
-            />
-          </div>
-        ))}
+        <SingleDataGraph
+          data={data}
+          hoveredTime={hoveredTime}
+          setHoveredTime={setHoveredTime}
+        />
       </div>
     );
   },
@@ -60,16 +56,38 @@ const SingleDataGraph = React.memo(
     setHoveredTime: (t: number | null) => void;
   }) => {
     const { currentTime, setCurrentTime } = useTime();
-    const chartData = useMemo(() => data, [data]);
-    const [dataKeys, setDataKeys] = useState<string[]>([]);
-    const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
+  const chartData = useMemo(() => data, [data]);
+  const [dataKeys, setDataKeys] = useState<string[]>([]);
+  const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
+  const [showLegend, setShowLegend] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("showLegend") === "true";
+  });
 
     useEffect(() => {
       if (!data || data.length === 0) return;
       const keys = Object.keys(data[0]).filter((k) => k !== "timestamp");
       setDataKeys(keys);
-      setVisibleKeys(keys);
+      const saved =
+        typeof window !== "undefined"
+          ? localStorage.getItem("visibleKeys")
+          : null;
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved) as string[];
+          setVisibleKeys(parsed.filter((k) => keys.includes(k)));
+        } catch {
+          setVisibleKeys(keys);
+        }
+      } else {
+        setVisibleKeys(keys);
+      }
     }, [data]);
+
+    useEffect(() => {
+      if (typeof window === "undefined") return;
+      localStorage.setItem("visibleKeys", JSON.stringify(visibleKeys));
+    }, [visibleKeys]);
 
     // Find the closest data point to the current time for highlighting
     const findClosestDataIndex = (time: number) => {
@@ -145,8 +163,24 @@ const SingleDataGraph = React.memo(
     };
 
     return (
-      <div className="flex w-full">
-        <div className="flex-1 h-80" onMouseLeave={handleMouseLeave}>
+      <div className="flex flex-col w-full">
+        <div className="flex justify-end mb-2">
+          <button
+            className="text-xs border border-slate-500 rounded px-2 py-1"
+            onClick={() =>
+              setShowLegend((prev) => {
+                const next = !prev;
+                if (typeof window !== "undefined") {
+                  localStorage.setItem("showLegend", next.toString());
+                }
+                return next;
+              })
+            }
+          >
+            {showLegend ? "Hide Fields" : "Show Fields"}
+          </button>
+        </div>
+        <div className="h-80" onMouseLeave={handleMouseLeave}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}
@@ -221,9 +255,11 @@ const SingleDataGraph = React.memo(
             </LineChart>
           </ResponsiveContainer>
         </div>
-        <div className="ml-4">
-          <CustomLegend />
-        </div>
+        {showLegend && (
+          <div className="mt-4">
+            <CustomLegend />
+          </div>
+        )}
       </div>
     );
   },

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -59,10 +59,12 @@ const SingleDataGraph = React.memo(
   const chartData = useMemo(() => data, [data]);
   const [dataKeys, setDataKeys] = useState<string[]>([]);
   const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
-  const [showLegend, setShowLegend] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem("showLegend") === "true";
-  });
+
+  const toggleAll = () => {
+    setVisibleKeys((prev) =>
+      prev.length === dataKeys.length ? [] : [...dataKeys],
+    );
+  };
 
     useEffect(() => {
       if (!data || data.length === 0) return;
@@ -77,10 +79,10 @@ const SingleDataGraph = React.memo(
           const parsed = JSON.parse(saved) as string[];
           setVisibleKeys(parsed.filter((k) => keys.includes(k)));
         } catch {
-          setVisibleKeys(keys);
+          setVisibleKeys([]);
         }
       } else {
-        setVisibleKeys(keys);
+        setVisibleKeys([]);
       }
     }, [data]);
 
@@ -167,17 +169,9 @@ const SingleDataGraph = React.memo(
         <div className="flex justify-end mb-2">
           <button
             className="text-xs border border-slate-500 rounded px-2 py-1"
-            onClick={() =>
-              setShowLegend((prev) => {
-                const next = !prev;
-                if (typeof window !== "undefined") {
-                  localStorage.setItem("showLegend", next.toString());
-                }
-                return next;
-              })
-            }
+            onClick={toggleAll}
           >
-            {showLegend ? "Hide Fields" : "Show Fields"}
+            {visibleKeys.length === dataKeys.length ? "Hide All Fields" : "Show All Fields"}
           </button>
         </div>
         <div className="h-80" onMouseLeave={handleMouseLeave}>
@@ -255,11 +249,9 @@ const SingleDataGraph = React.memo(
             </LineChart>
           </ResponsiveContainer>
         </div>
-        {showLegend && (
-          <div className="mt-4">
-            <CustomLegend />
-          </div>
-        )}
+        <div className="mt-4">
+          <CustomLegend />
+        </div>
       </div>
     );
   },

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -22,13 +22,14 @@ type ColumnGroup = {
 type DataGraphProps = {
   data: Array<Record<string, number>>;
   columns: ColumnGroup[];
+  datasetId: string;
   onChartsReady?: () => void;
 };
 
 import React, { useMemo } from "react";
 
 export const DataRecharts = React.memo(
-  ({ data, columns, onChartsReady }: DataGraphProps) => {
+  ({ data, columns, datasetId, onChartsReady }: DataGraphProps) => {
     // Shared hoveredTime for all graphs
     const [hoveredTime, setHoveredTime] = useState<number | null>(null);
 
@@ -45,6 +46,7 @@ export const DataRecharts = React.memo(
         <SingleDataGraph
           data={data}
           columns={columns}
+          datasetId={datasetId}
           hoveredTime={hoveredTime}
           setHoveredTime={setHoveredTime}
         />
@@ -58,11 +60,13 @@ const SingleDataGraph = React.memo(
   ({
     data,
     columns,
+    datasetId,
     hoveredTime,
     setHoveredTime,
   }: {
     data: Array<Record<string, number>>;
     columns: ColumnGroup[];
+    datasetId: string;
     hoveredTime: number | null;
     setHoveredTime: (t: number | null) => void;
   }) => {
@@ -70,6 +74,7 @@ const SingleDataGraph = React.memo(
   const chartData = useMemo(() => data, [data]);
   const [dataKeys, setDataKeys] = useState<string[]>([]);
   const [visibleKeys, setVisibleKeys] = useState<string[]>([]);
+  const storageKey = `visibleKeys:${datasetId}`;
 
   const toggleAll = () => {
     setVisibleKeys((prev) =>
@@ -83,7 +88,7 @@ const SingleDataGraph = React.memo(
       setDataKeys(keys);
       const saved =
         typeof window !== "undefined"
-          ? localStorage.getItem("visibleKeys")
+          ? localStorage.getItem(storageKey)
           : null;
       if (saved) {
         try {
@@ -95,12 +100,12 @@ const SingleDataGraph = React.memo(
       } else {
         setVisibleKeys([]);
       }
-    }, [data]);
+    }, [data, storageKey]);
 
     useEffect(() => {
       if (typeof window === "undefined") return;
-      localStorage.setItem("visibleKeys", JSON.stringify(visibleKeys));
-    }, [visibleKeys]);
+      localStorage.setItem(storageKey, JSON.stringify(visibleKeys));
+    }, [visibleKeys, storageKey]);
 
     // Find the closest data point to the current time for highlighting
     const findClosestDataIndex = (time: number) => {
@@ -149,58 +154,61 @@ const SingleDataGraph = React.memo(
         });
       };
 
-      const colorMap = useMemo(() => {
-        const map = new Map<string, string>();
-        dataKeys.forEach((k, idx) => {
-          map.set(k, `hsl(${(idx * 360) / dataKeys.length}, 100%, 50%)`);
-        });
-        return map;
-      }, [dataKeys]);
-
+      const maxIndices = Math.max(...columns.map((c) => c.value.length));
       return (
-        <div className="flex flex-col gap-3 mx-4">
-          {columns.map((col) => {
-            const allChecked = col.value.every((k) => visibleKeys.includes(k));
-            return (
-              <div key={col.key} className="flex items-start gap-4">
-                <label className="flex gap-2 w-36 select-none">
-                  <input
-                    type="checkbox"
-                    className="size-3.5 mt-1"
-                    checked={allChecked}
-                    onChange={() => handleColumnToggle(col)}
-                  />
-                  <span className="text-sm truncate">{col.key}</span>
-                </label>
-                <div className="flex flex-wrap gap-4">
-                  {col.value.map((key) => {
-                    const color = colorMap.get(key) || "#fff";
-                    const isChecked = visibleKeys.includes(key);
-                    const label = key.split(SERIES_NAME_DELIMITER)[1] || key;
-                    return (
-                      <label key={key} className="flex gap-1 cursor-pointer select-none">
+        <div className="overflow-x-auto mx-4">
+          <table className="text-sm">
+            <thead>
+              <tr>
+                <th className="text-left pr-4">field</th>
+                {Array.from({ length: maxIndices }).map((_, i) => (
+                  <th key={i} className="px-2 text-center">{i}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {columns.map((col) => {
+                const allChecked = col.value.every((k) => visibleKeys.includes(k));
+                return (
+                  <tr key={col.key} className="align-top">
+                    <td className="pr-4 whitespace-nowrap w-48">
+                      <label className="flex gap-2 select-none">
                         <input
                           type="checkbox"
-                          checked={isChecked}
-                          onChange={() => handleCheckboxChange(key)}
-                          className="size-3.5 mt-1"
-                          style={{ accentColor: color }}
+                          className="size-3.5"
+                          checked={allChecked}
+                          onChange={() => handleColumnToggle(col)}
                         />
-                        <span className={`text-sm ${isChecked ? 'text-white' : 'text-gray-400'}`}>{label}</span>
-                        <span className={`text-sm font-mono ml-1 ${isChecked ? 'text-orange-300' : 'text-gray-500'}`}>{typeof currentData[key] === 'number' ? currentData[key].toFixed(2) : '--'}</span>
+                        <span>{col.key}</span>
                       </label>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
+                    </td>
+                    {Array.from({ length: maxIndices }).map((_, idx) => {
+                      const key = col.value[idx];
+                      if (!key)
+                        return <td key={idx} className="px-2" />;
+                      const isChecked = visibleKeys.includes(key);
+                      return (
+                        <td key={idx} className="px-2 text-center">
+                          <input
+                            type="checkbox"
+                            className="size-3.5"
+                            checked={isChecked}
+                            onChange={() => handleCheckboxChange(key)}
+                          />
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         </div>
       );
     };
     return (
       <div>
-        <div className="h-80" onMouseLeave={handleMouseLeave}>
+        <div className="h-96" onMouseLeave={handleMouseLeave}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={chartData}


### PR DESCRIPTION
## Summary
- tweak layout ratio to 50/50 and use a single chart
- reposition chart legend below the chart and add a show/hide toggle
- remember visible fields across episodes using localStorage

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a41ea7c48832a865b6ca634d85fd4