### PR TITLE
Use CloudFront URLs in viewer

### DIFF
--- a/lerobot/html_dataset_visualizer/README.md
+++ b/lerobot/html_dataset_visualizer/README.md
@@ -63,7 +63,7 @@ You can start editing the page by modifying `src/app/page.tsx` or other files in
 - `CLOUDFRONT_DOMAIN`: (optional) CloudFront distribution domain.
 - `CLOUDFRONT_KEY_PAIR_ID`: (optional) Key pair ID for signing URLs.
 - `CLOUDFRONT_PRIVATE_KEY_SECRET`: (optional) AWS Secrets Manager secret name containing the private key.
-  The secret may hold the PEM directly or base64 encoded binary.
+  The secret may hold the PEM string, a base64‑encoded PEM, or DER binary data.
 - `CLOUDFRONT_PRIVATE_KEY`: (optional) Use this PEM string directly instead of fetching from Secrets Manager.
 
 ## Contributing

--- a/lerobot/html_dataset_visualizer/README.md
+++ b/lerobot/html_dataset_visualizer/README.md
@@ -29,6 +29,7 @@ This tool is designed to help robotics researchers and practitioners quickly ins
 ## Getting Started
 
 For node and npm installation:
+
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 source ~/.bashrc  # or ~/.zshrc, depending on your shell
@@ -62,6 +63,7 @@ You can start editing the page by modifying `src/app/page.tsx` or other files in
 - `CLOUDFRONT_DOMAIN`: (optional) CloudFront distribution domain.
 - `CLOUDFRONT_KEY_PAIR_ID`: (optional) Key pair ID for signing URLs.
 - `CLOUDFRONT_PRIVATE_KEY_SECRET`: (optional) AWS Secrets Manager secret name containing the private key.
+  The secret may hold the PEM directly or base64 encoded binary.
 
 ## Contributing
 

--- a/lerobot/html_dataset_visualizer/README.md
+++ b/lerobot/html_dataset_visualizer/README.md
@@ -59,6 +59,9 @@ You can start editing the page by modifying `src/app/page.tsx` or other files in
 ### Environment Variables
 
 - `DATASET_URL`: (optional) Base URL for dataset hosting (defaults to HuggingFace Datasets).
+- `CLOUDFRONT_DOMAIN`: (optional) CloudFront distribution domain.
+- `CLOUDFRONT_KEY_PAIR_ID`: (optional) Key pair ID for signing URLs.
+- `CLOUDFRONT_PRIVATE_KEY_SECRET`: (optional) AWS Secrets Manager secret name containing the private key.
 
 ## Contributing
 

--- a/lerobot/html_dataset_visualizer/README.md
+++ b/lerobot/html_dataset_visualizer/README.md
@@ -64,6 +64,7 @@ You can start editing the page by modifying `src/app/page.tsx` or other files in
 - `CLOUDFRONT_KEY_PAIR_ID`: (optional) Key pair ID for signing URLs.
 - `CLOUDFRONT_PRIVATE_KEY_SECRET`: (optional) AWS Secrets Manager secret name containing the private key.
   The secret may hold the PEM directly or base64 encoded binary.
+- `CLOUDFRONT_PRIVATE_KEY`: (optional) Use this PEM string directly instead of fetching from Secrets Manager.
 
 ## Contributing
 

--- a/lerobot/html_dataset_visualizer/package-lock.json
+++ b/lerobot/html_dataset_visualizer/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.812.0",
         "@aws-sdk/client-s3": "^3.812.0",
+        "@aws-sdk/client-secrets-manager": "^3.812.0",
         "@aws-sdk/lib-dynamodb": "^3.814.0",
+        "@aws-sdk/cloudfront-signer": "^3.812.0",
         "@aws-sdk/s3-request-presigner": "^3.812.0",
         "hyparquet": "^1.12.1",
         "next": "^15.3.2",

--- a/lerobot/html_dataset_visualizer/package.json
+++ b/lerobot/html_dataset_visualizer/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.812.0",
     "@aws-sdk/client-s3": "^3.812.0",
+    "@aws-sdk/client-secrets-manager": "^3.812.0",
     "@aws-sdk/lib-dynamodb": "^3.814.0",
+    "@aws-sdk/cloudfront-signer": "^3.812.0",
     "@aws-sdk/s3-request-presigner": "^3.812.0",
     "hyparquet": "^1.12.1",
     "next": "^15.3.2",

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -6,8 +6,7 @@ import {
   readParquetColumn,
 } from "@/utils/parquetUtils";
 import { pick } from "@/utils/pick";
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { getSignedCloudFrontUrl } from "@/utils/cloudfront";
 
 const DATASET_URL =
   process.env.DATASET_URL || "https://huggingface.co/datasets";
@@ -20,21 +19,14 @@ export async function getEpisodeData(
   episodeId: number,
 ) {
   const repoId = `${org}/${dataset}`;
-  const bucket = "configint";
   const keyPrefix = `data-builder/${org}/data/${dataset}`.replace(/\/$/, "");
-  const s3Client = new S3Client({ region: "us-east-2" });
 
-  const getSignedS3Url = async (key: string) => {
-    const command = new GetObjectCommand({
-      Bucket: bucket,
-      Key: `${keyPrefix}/${key}`,
-    });
-    return getSignedUrl(s3Client, command, { expiresIn: 3600 });
-  };
+  const getSignedUrl = async (key: string) =>
+    getSignedCloudFrontUrl(`${keyPrefix}/${key}`);
 
   try {
     const episode_chunk = Math.floor(0 / 1000);
-    const jsonUrl = await getSignedS3Url("meta/info.json");
+    const jsonUrl = await getSignedUrl("meta/info.json");
 
     const info = await fetchJson<DatasetMetadata>(jsonUrl);
 
@@ -57,7 +49,7 @@ export async function getEpisodeData(
     const episodesLabels: Record<number, string> = {};
     const episodesTasks: Record<number, string[]> = {};
     try {
-      const episodesUrl = await getSignedS3Url("meta/episodes.jsonl");
+      const episodesUrl = await getSignedUrl("meta/episodes.jsonl");
       const text = await (await fetch(episodesUrl)).text();
       const episodesData = text
         .split("\n")
@@ -86,7 +78,7 @@ export async function getEpisodeData(
         });
         return {
           filename: key,
-          url: await getSignedS3Url(videoPath),
+          url: await getSignedUrl(videoPath),
         };
       });
     // videosInfo is now array of promises, resolve them
@@ -139,7 +131,7 @@ export async function getEpisodeData(
       episode_index: episodeId.toString().padStart(6, "0"),
     });
 
-    const parquetUrl = await getSignedS3Url(parquetKey);
+    const parquetUrl = await getSignedUrl(parquetKey);
 
     const arrayBuffer = await fetchParquetFile(parquetUrl);
     const data = await readParquetColumn(arrayBuffer, filteredColumnNames);

--- a/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
@@ -7,12 +7,7 @@ import {
 } from "@/utils/parquetUtils";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
-import {
-  S3Client,
-  HeadObjectCommand,
-  GetObjectCommand,
-} from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { getSignedCloudFrontUrl } from "@/utils/cloudfront";
 
 // Server component for data fetching
 export default async function ExplorePage({
@@ -79,23 +74,18 @@ export default async function ExplorePage({
   }
 
   // Fetch episode 0 data for each dataset
-  const s3Client = new S3Client({ region: "us-east-2" });
   const datasetWithVideos = (
     await Promise.all(
       datasets.map(async (ds: { id: string; s3_dir: string }) => {
         try {
           const { id, s3_dir } = ds;
-          // Parse S3 URI (e.g. s3://my-bucket/path/to/dataset)
-          const [bucket, ...keyParts] = s3_dir.split("/");
+          // Parse S3 URI like bucket/prefix and keep only key prefix
+          const [, ...keyParts] = s3_dir.split("/");
           const keyPrefix = keyParts.join("/").replace(/\/$/, "");
 
           // ------- meta/info.json -------
           const infoKey = `${keyPrefix}/meta/info.json`;
-          const infoUrl = await getSignedUrl(
-            s3Client,
-            new GetObjectCommand({ Bucket: bucket, Key: infoKey }),
-            { expiresIn: 3600 },
-          );
+          const infoUrl = await getSignedCloudFrontUrl(infoKey);
           const info = await fetchJson<DatasetMetadata>(infoUrl);
 
           // Find first video‑type feature
@@ -114,22 +104,7 @@ export default async function ExplorePage({
               episode_index: "0".padStart(6, "0"),
             });
             const videoKey = `${keyPrefix}/${videoPath}`;
-
-            try {
-              // Check object exists
-              await s3Client.send(
-                new HeadObjectCommand({ Bucket: bucket, Key: videoKey }),
-              );
-
-              // Sign and keep URL
-              videoUrl = await getSignedUrl(
-                s3Client,
-                new GetObjectCommand({ Bucket: bucket, Key: videoKey }),
-                { expiresIn: 3600 },
-              );
-            } catch {
-              /* object missing – leave videoUrl null */
-            }
+            videoUrl = await getSignedCloudFrontUrl(videoKey);
           }
 
           return videoUrl ? { id, videoUrl } : null;

--- a/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
@@ -11,42 +11,55 @@ const secretName = process.env.CLOUDFRONT_PRIVATE_KEY_SECRET || "configint";
 const region = process.env.AWS_REGION || "us-east-2";
 
 const secretsClient = new SecretsManagerClient({ region });
-let cachedKey: string | null = null;
+// Cache the resolved private key so we don't fetch from Secrets Manager
+// repeatedly. The key may be returned either as a PEM string or raw Buffer
+// depending on how it's stored.
+let cachedKey: string | Buffer | null = null;
 
-async function getPrivateKey(): Promise<string> {
+async function getPrivateKey(): Promise<string | Buffer> {
   if (!cachedKey) {
+    let keyData: string | Buffer;
+
     if (process.env.CLOUDFRONT_PRIVATE_KEY) {
-      cachedKey = process.env.CLOUDFRONT_PRIVATE_KEY;
+      keyData = process.env.CLOUDFRONT_PRIVATE_KEY;
     } else {
       const resp = await secretsClient.send(
         new GetSecretValueCommand({ SecretId: secretName }),
       );
+
       if (resp.SecretString) {
-        cachedKey = resp.SecretString;
+        keyData = resp.SecretString;
       } else if (resp.SecretBinary) {
-        const bytes =
+        keyData =
           resp.SecretBinary instanceof Uint8Array
             ? Buffer.from(resp.SecretBinary)
             : Buffer.from(resp.SecretBinary as string, "base64");
-        cachedKey = bytes.toString("utf-8");
       } else {
         throw new Error(`Secret ${secretName} is empty`);
       }
     }
 
-    if (cachedKey.includes("\\n")) {
-      cachedKey = cachedKey.replace(/\\n/g, "\n");
-    }
-    if (!cachedKey.includes("BEGIN")) {
-      try {
-        const decoded = Buffer.from(cachedKey, "base64").toString("utf-8");
-        if (decoded.includes("BEGIN")) {
-          cachedKey = decoded;
+    if (typeof keyData === "string") {
+      // Handle escaped newlines from environment variables
+      if (keyData.includes("\\n")) {
+        keyData = keyData.replace(/\\n/g, "\n");
+      }
+
+      // If the string doesn't look like PEM, attempt base64 decode. If the
+      // decoded data still looks textual and contains the PEM header, use the
+      // decoded string. Otherwise keep the binary Buffer for DER formatted keys.
+      if (!keyData.includes("BEGIN")) {
+        try {
+          const buf = Buffer.from(keyData, "base64");
+          const asText = buf.toString("utf-8");
+          keyData = asText.includes("BEGIN") ? asText : buf;
+        } catch {
+          /* ignore */
         }
-      } catch {
-        /* ignore */
       }
     }
+
+    cachedKey = keyData;
   }
   return cachedKey;
 }

--- a/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
@@ -1,0 +1,34 @@
+import { getSignedUrl as cfGetSignedUrl } from "@aws-sdk/cloudfront-signer";
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager";
+
+const domain =
+  process.env.CLOUDFRONT_DOMAIN || "https://d3keuzsn7dd5q1.cloudfront.net";
+const keyPairId = process.env.CLOUDFRONT_KEY_PAIR_ID || "K1REJ1HDDLE7OS";
+const secretName = process.env.CLOUDFRONT_PRIVATE_KEY_SECRET || "configint";
+const region = process.env.AWS_REGION || "us-east-2";
+
+const secretsClient = new SecretsManagerClient({ region });
+let cachedKey: string | null = null;
+
+async function getPrivateKey(): Promise<string> {
+  if (!cachedKey) {
+    const resp = await secretsClient.send(
+      new GetSecretValueCommand({ SecretId: secretName }),
+    );
+    cachedKey = resp.SecretString || "";
+  }
+  return cachedKey;
+}
+
+export async function getSignedCloudFrontUrl(path: string): Promise<string> {
+  const privateKey = await getPrivateKey();
+  return cfGetSignedUrl({
+    url: `${domain}/${path.replace(/^\//, "")}`,
+    keyPairId,
+    dateLessThan: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    privateKey,
+  });
+}

--- a/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
@@ -18,7 +18,17 @@ async function getPrivateKey(): Promise<string> {
     const resp = await secretsClient.send(
       new GetSecretValueCommand({ SecretId: secretName }),
     );
-    cachedKey = resp.SecretString || "";
+    if (resp.SecretString) {
+      cachedKey = resp.SecretString;
+    } else if (resp.SecretBinary) {
+      const bytes =
+        resp.SecretBinary instanceof Uint8Array
+          ? Buffer.from(resp.SecretBinary)
+          : Buffer.from(resp.SecretBinary as string, "base64");
+      cachedKey = bytes.toString("utf-8");
+    } else {
+      throw new Error(`Secret ${secretName} is empty`);
+    }
   }
   return cachedKey;
 }

--- a/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
@@ -15,19 +15,37 @@ let cachedKey: string | null = null;
 
 async function getPrivateKey(): Promise<string> {
   if (!cachedKey) {
-    const resp = await secretsClient.send(
-      new GetSecretValueCommand({ SecretId: secretName }),
-    );
-    if (resp.SecretString) {
-      cachedKey = resp.SecretString;
-    } else if (resp.SecretBinary) {
-      const bytes =
-        resp.SecretBinary instanceof Uint8Array
-          ? Buffer.from(resp.SecretBinary)
-          : Buffer.from(resp.SecretBinary as string, "base64");
-      cachedKey = bytes.toString("utf-8");
+    if (process.env.CLOUDFRONT_PRIVATE_KEY) {
+      cachedKey = process.env.CLOUDFRONT_PRIVATE_KEY;
     } else {
-      throw new Error(`Secret ${secretName} is empty`);
+      const resp = await secretsClient.send(
+        new GetSecretValueCommand({ SecretId: secretName }),
+      );
+      if (resp.SecretString) {
+        cachedKey = resp.SecretString;
+      } else if (resp.SecretBinary) {
+        const bytes =
+          resp.SecretBinary instanceof Uint8Array
+            ? Buffer.from(resp.SecretBinary)
+            : Buffer.from(resp.SecretBinary as string, "base64");
+        cachedKey = bytes.toString("utf-8");
+      } else {
+        throw new Error(`Secret ${secretName} is empty`);
+      }
+    }
+
+    if (cachedKey.includes("\\n")) {
+      cachedKey = cachedKey.replace(/\\n/g, "\n");
+    }
+    if (!cachedKey.includes("BEGIN")) {
+      try {
+        const decoded = Buffer.from(cachedKey, "base64").toString("utf-8");
+        if (decoded.includes("BEGIN")) {
+          cachedKey = decoded;
+        }
+      } catch {
+        /* ignore */
+      }
     }
   }
   return cachedKey;


### PR DESCRIPTION
## Summary
- add utility to generate CloudFront signed URLs
- fetch dataset assets through CloudFront instead of S3
- document CloudFront environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_684a6caeeed0832aa1f004a28b56525b