### PR TITLE
Fix Next.js params usage

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -25,11 +25,18 @@ export async function getEpisodeData(
     return getSignedUrl("configint", `${keyPrefix}/${key}`);
   };
 
+  const publicUrl = (key: string) =>
+    `${DATASET_URL}/${repoId}/resolve/main/${key}`;
+
   try {
     const episode_chunk = Math.floor(0 / 1000);
     const jsonUrl = await sign("meta/info.json");
-
-    const info = await fetchJson<DatasetMetadata>(jsonUrl);
+    let info: DatasetMetadata;
+    try {
+      info = await fetchJson<DatasetMetadata>(jsonUrl);
+    } catch {
+      info = await fetchJson<DatasetMetadata>(publicUrl("meta/info.json"));
+    }
 
     // Dataset information
     const datasetInfo = {
@@ -65,7 +72,25 @@ export async function getEpisodeData(
         episodesTasks[epNum] = Array.isArray(ep.tasks) ? ep.tasks : [];
       }
     } catch (err) {
-      console.warn("Failed to fetch episodes.jsonl", err);
+      try {
+        const text = await (
+          await fetch(publicUrl("meta/episodes.jsonl"))
+        ).text();
+        const episodesData = text
+          .split("\n")
+          .filter((line) => line.trim().length)
+          .map((line) => JSON.parse(line));
+        for (const ep of episodesData) {
+          const epNum = Number(ep.episode_index) + 1;
+          const labelPath = Array.isArray(ep.input_key)
+            ? ep.input_key[1].split("/").slice(-5).join("/")
+            : "";
+          episodesLabels[epNum] = `${epNum}: ${labelPath}`;
+          episodesTasks[epNum] = Array.isArray(ep.tasks) ? ep.tasks : [];
+        }
+      } catch (err2) {
+        console.warn("Failed to fetch episodes.jsonl", err2);
+      }
     }
 
     // Videos information

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -6,9 +6,9 @@ export const dynamic = "force-dynamic";
 export async function generateMetadata({
   params,
 }: {
-  params: { org: string; dataset: string; episode: string };
+  params: Promise<{ org: string; dataset: string; episode: string }>;
 }) {
-  const { org, dataset, episode } = params;
+  const { org, dataset, episode } = await params;
   return {
     title: `${org}/${dataset} | episode ${episode}`,
   };
@@ -17,10 +17,10 @@ export async function generateMetadata({
 export default async function EpisodePage({
   params,
 }: {
-  params: { org: string; dataset: string; episode: string };
+  params: Promise<{ org: string; dataset: string; episode: string }>;
 }) {
   // episode is like 'episode_1'
-  const { org, dataset, episode } = params;
+  const { org, dataset, episode } = await params;
   // fetchData should be updated if needed to support this path pattern
   let episodeNumber = Number(episode.replace(/^episode_/, ""));
   if (episodeNumber) {

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/page.tsx
@@ -1,10 +1,11 @@
 import { redirect } from "next/navigation";
 
-export default function DatasetRootPage({
+export default async function DatasetRootPage({
   params,
 }: {
-  params: { org: string; dataset: string };
+  params: Promise<{ org: string; dataset: string }>;
 }) {
-  redirect(`/${params.org}/${params.dataset}/episode_1`);
+  const { org, dataset } = await params;
+  redirect(`/${org}/${dataset}/episode_1`);
   return null;
 }


### PR DESCRIPTION
## Summary
- await `params` in episode metadata
- await `params` in episode page
- await `params` in dataset root page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a7a592594832a9b553518791fedf1