### PR TITLE
Fix dataset viewer header position

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -178,40 +178,37 @@ function EpisodeViewerInner({ data }: { data: any }) {
         nextPage={nextPage}
       />
 
+      {/* Fixed header on top right */}
+      <div className="fixed top-0 right-0 flex flex-col items-end p-4 z-20 text-right">
+        <a
+          href="https://github.com/huggingface/lerobot"
+          target="_blank"
+          className="block"
+        >
+          <img
+            src="https://github.com/huggingface/lerobot/raw/main/media/lerobot-logo-thumbnail.png"
+            alt="LeRobot Logo"
+            className="w-24"
+          />
+        </a>
+        <a
+          href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
+          target="_blank"
+        >
+          <p className="text-lg font-semibold">{datasetInfo.repoId}</p>
+        </a>
+        <p className="font-mono text-lg font-semibold">
+          episode {episodeId}
+          {episodeLabelPath && `: ${episodeLabelPath}`}
+        </p>
+      </div>
+
       <div className="flex flex-1 overflow-hidden">
         {/* Videos column */}
         <div
           className={`flex w-[50%] flex-col gap-4 p-4 relative ${isLoading ? "overflow-hidden" : "overflow-y-auto"}`}
         >
           {isLoading && <Loading />}
-
-          <div className="flex items-center justify-start my-4">
-            <a
-              href="https://github.com/huggingface/lerobot"
-              target="_blank"
-              className="block"
-            >
-              <img
-                src="https://github.com/huggingface/lerobot/raw/main/media/lerobot-logo-thumbnail.png"
-                alt="LeRobot Logo"
-                className="w-32"
-              />
-            </a>
-
-            <div>
-              <a
-                href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
-                target="_blank"
-              >
-                <p className="text-lg font-semibold">{datasetInfo.repoId}</p>
-              </a>
-
-              <p className="font-mono text-lg font-semibold">
-                episode {episodeId}
-                {episodeLabelPath && `: ${episodeLabelPath}`}
-              </p>
-            </div>
-          </div>
 
           {tasks?.length > 0 && (
             <p className="text-lg mb-2">

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -225,8 +225,8 @@ function EpisodeViewerInner({ data }: { data: any }) {
         </div>
 
         {/* Charts column */}
-        <div className="flex w-[50%] flex-col p-4 items-center justify-center">
-          <div className="w-full max-w-full">
+        <div className="flex w-[50%] flex-col p-4 items-center pt-36 overflow-hidden">
+          <div className="w-full max-w-full flex-1 flex flex-col overflow-hidden">
             <DataRecharts
               data={chartData}
               columns={columns}

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -201,6 +201,11 @@ function EpisodeViewerInner({ data }: { data: any }) {
           episode {episodeId}
           {episodeLabelPath && `: ${episodeLabelPath}`}
         </p>
+        {tasks?.length > 0 && (
+          <p className="text-lg mt-2">
+            tasks: <span className="font-mono">{tasks.join(', ')}</span>
+          </p>
+        )}
       </div>
 
       <div className="flex flex-1 overflow-hidden">
@@ -210,11 +215,6 @@ function EpisodeViewerInner({ data }: { data: any }) {
         >
           {isLoading && <Loading />}
 
-          {tasks?.length > 0 && (
-            <p className="text-lg mb-2">
-              tasks: <span className="font-mono">{tasks.join(", ")}</span>
-            </p>
-          )}
 
           {videosInfo.length && (
             <VideosPlayer

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -222,8 +222,6 @@ function EpisodeViewerInner({ data }: { data: any }) {
               onVideosReady={() => setVideosReady(true)}
             />
           )}
-
-          <PlaybackBar />
         </div>
 
         {/* Charts column */}
@@ -245,6 +243,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
               </p>
             )}
           </div>
+          <PlaybackBar />
         </div>
       </div>
     </div>

--- a/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/data-recharts.tsx
@@ -42,7 +42,7 @@ export const DataRecharts = React.memo(
     }, [onChartsReady]);
 
     return (
-      <div className="flex flex-col gap-4 overflow-y-auto pr-4">
+      <div className="flex flex-col h-full pr-4">
         <SingleDataGraph
           data={data}
           columns={columns}
@@ -172,7 +172,7 @@ const SingleDataGraph = React.memo(
 
       const maxIndices = Math.max(...columns.map((c) => c.value.length));
       return (
-        <div className="overflow-x-auto mx-4">
+        <div className="overflow-x-auto mx-4 max-h-[40vh] overflow-y-auto">
           <table className="text-sm">
             <thead>
               <tr>
@@ -302,7 +302,7 @@ const SingleDataGraph = React.memo(
             </LineChart>
           </ResponsiveContainer>
         </div>
-        <div className="mt-4">
+        <div className="mt-4 flex-1 overflow-y-auto">
           <CustomLegend />
         </div>
         <div className="flex justify-end mt-2">


### PR DESCRIPTION
## Summary
- keep episode header fixed at the top-right of the viewer

## Testing
- `pytest -q tests/test_available.py` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_684a7f0f21b0832a97f7b071723d0628