### PR TITLE
Fix header alignment

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -179,7 +179,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
       />
 
       {/* Fixed header on top right */}
-      <div className="fixed top-0 right-0 flex flex-col items-end p-4 z-20 text-right">
+      <div className="fixed top-0 right-0 flex flex-col items-start p-4 z-20 text-left">
         <a
           href="https://github.com/huggingface/lerobot"
           target="_blank"

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -178,8 +178,8 @@ function EpisodeViewerInner({ data }: { data: any }) {
         nextPage={nextPage}
       />
 
-      {/* Fixed header on top right */}
-      <div className="fixed top-0 right-0 flex flex-col items-start p-4 z-20 text-left">
+      {/* Fixed header on top of the charts column */}
+      <div className="fixed top-0 left-[calc(50%+7.5rem)] flex flex-col items-start p-4 z-20 text-left">
         <a
           href="https://github.com/huggingface/lerobot"
           target="_blank"


### PR DESCRIPTION
## Summary
- left-align dataset header info in episode viewer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_684a891332cc832a88bb8f60e5d53fa1