### PR TITLE
Fix label path extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,8 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Node.js dependencies at repository root
+/node_modules
+/package.json
+/package-lock.json

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -58,9 +58,20 @@ export async function getEpisodeData(
         .map((line) => JSON.parse(line));
       for (const ep of episodesData) {
         const epNum = Number(ep.episode_index) + 1;
-        const labelPath = Array.isArray(ep.input_key)
-          ? ep.input_key[1].split("/").slice(-5).join("/")
-          : "";
+        let labelPath = "";
+        if (Array.isArray(ep.input_key)) {
+          labelPath = ep.input_key[1]
+            .split("/")
+            .filter(Boolean)
+            .slice(-5)
+            .join("/");
+        } else if (typeof ep.input_key === "string") {
+          labelPath = ep.input_key
+            .split("/")
+            .filter(Boolean)
+            .slice(-5)
+            .join("/");
+        }
         episodesLabels[epNum] = `${epNum}: ${labelPath}`;
         episodesTasks[epNum] = Array.isArray(ep.tasks) ? ep.tasks : [];
       }


### PR DESCRIPTION
## Summary
- parse `input_key` for dataset labels in a more robust way
- ignore root `node_modules` and package files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_684ffba275c8832aae7d18a100a45dce