### PR TITLE
Fix episode indexing to start from 0

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -57,7 +57,7 @@ export async function getEpisodeData(
         .filter((line) => line.trim().length)
         .map((line) => JSON.parse(line));
       for (const ep of episodesData) {
-        const epNum = Number(ep.episode_index) + 1;
+        const epNum = Number(ep.episode_index);
         let labelPath = "";
         if (Array.isArray(ep.input_key)) {
           labelPath = ep.input_key[1]
@@ -174,13 +174,13 @@ export async function getEpisodeData(
 
     return {
       datasetInfo,
-      episodeId: episodeId + 1,
+      episodeId,
       videosInfo: resolvedVideosInfo,
       chartData,
       columns,
       episodes,
       episodeLabels: episodesLabels,
-      tasks: episodesTasks[episodeId + 1] ?? [],
+      tasks: episodesTasks[episodeId] ?? [],
       ignoredColumns,
       duration,
     };

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -19,13 +19,10 @@ export default async function EpisodePage({
 }: {
   params: { org: string; dataset: string; episode: string };
 }) {
-  // episode is like 'episode_1'
+  // episode is like 'episode_0'
   const { org, dataset, episode } = params;
   // fetchData should be updated if needed to support this path pattern
-  let episodeNumber = Number(episode.replace(/^episode_/, ""));
-  if (episodeNumber) {
-    episodeNumber--;
-  }
+  const episodeNumber = Number(episode.replace(/^episode_/, ""));
   const { data, error } = await getEpisodeDataSafe(org, dataset, episodeNumber);
   return <EpisodeViewer data={data} error={error} />;
 }


### PR DESCRIPTION
## Summary
- remove 1-based offset in the dataset visualizer
- parse episode route directly without subtracting 1

## Testing
- `pre-commit run --files lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513a35ccd4832a9d7700eb2ae7fedb