### PR TITLE
Fix episode indexing in visualizer

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -42,8 +42,8 @@ export async function getEpisodeData(
     // Generate list of episodes
     const episodes = Array.from(
       { length: datasetInfo.total_episodes },
-      // episode id starts from 1
-      (_, i) => i + 1,
+      // episode index starts from 0
+      (_, i) => i,
     );
 
     // Fetch episode metadata to build labels and tasks


### PR DESCRIPTION
## Summary
- correct episodes array to start from 0 instead of 1

## Testing
- `pytest -k ""` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68516b510690832a8638c40852b72522