### PR TITLE
Show dataset duration

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -37,6 +37,7 @@ export async function getEpisodeData(
       total_frames: info.total_frames,
       total_episodes: info.total_episodes,
       fps: info.fps,
+      total_duration_hours: info.total_frames / info.fps / 3600,
     };
 
     // Generate list of episodes

--- a/lerobot/html_dataset_visualizer/src/components/side-nav.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/side-nav.tsx
@@ -56,7 +56,10 @@ const Sidebar: React.FC<SidebarProps> = ({
         aria-label="Sidebar navigation"
       >
         <ul>
-          <li>Number of samples/frames: {datasetInfo.total_frames}</li>
+          <li>
+            Dataset duration (hours):{" "}
+            {datasetInfo.total_duration_hours.toFixed(2)}
+          </li>
           <li>Number of episodes: {datasetInfo.total_episodes}</li>
           <li>Frames per second: {datasetInfo.fps}</li>
         </ul>


### PR DESCRIPTION
## Summary
- compute dataset duration from total frames
- show duration in hours in sidebar instead of frame count

## Testing
- `npm --prefix lerobot/html_dataset_visualizer run format`
- `npm --prefix lerobot/html_dataset_visualizer run lint` *(fails: 403 Forbidden)*
- `pytest -k ""` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68516f6532d8832aaa99e920d464ea0b