### PR TITLE
Fix repoId generation

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -18,7 +18,10 @@ export async function getEpisodeData(
   dataset: string,
   episodeId: number,
 ) {
-  const repoId = `${org}/${dataset}`;
+  const tokens = dataset.split("-");
+  const organization = tokens[0];
+  const datasetName = tokens.slice(1).join("-") || tokens[0];
+  const repoId = `${organization}/${datasetName}`;
   const keyPrefix = `data-builder/${org}/data/${dataset}`.replace(/\/$/, "");
 
   const sign = async (key: string) => {

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -8,9 +8,12 @@ export async function generateMetadata({
 }: {
   params: { org: string; dataset: string; episode: string };
 }) {
-  const { org, dataset, episode } = params;
+  const { dataset, episode } = params;
+  const tokens = dataset.split("-");
+  const organization = tokens[0];
+  const datasetName = tokens.slice(1).join("-") || tokens[0];
   return {
-    title: `${org}/${dataset} | episode ${episode}`,
+    title: `${organization}/${datasetName} | episode ${episode}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- fix repoId by parsing organization and dataset from dataset name
- update episode page metadata to use derived organization and dataset names

## Testing
- `pytest -k html_dataset_visualizer -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852a835641c832a981f4b83a5323006