### PR TITLE
Fix dataset org name parsing

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
@@ -32,10 +32,14 @@ export default async function ExplorePage({
     );
 
     const builderDatasets = (scanBuilder.Items || []).map(
-      (item: { version: string; data_name: string }) => ({
-        id: `${item.version}/${item.data_name}`,
-        s3_dir: `configint/data-builder/${item.version}/data/${item.data_name}/`,
-      }),
+      (item: { version: string; data_name: string }) => {
+        const [org, ...datasetParts] = item.data_name.split("-");
+        const datasetName = datasetParts.join("-");
+        return {
+          id: `${org}/${datasetName}`,
+          s3_dir: `configint/data-builder/${item.version}/data/${item.data_name}/`,
+        };
+      },
     );
 
     const scanVisualizer = await docClient.send(
@@ -51,8 +55,11 @@ export default async function ExplorePage({
           /^configint\/data-builder\/(.+)\/data\/(.+)\/$/,
         );
         if (!match) return null;
+        const [, version, dataName] = match;
+        const [org, ...datasetParts] = dataName.split("-");
+        const datasetName = datasetParts.join("-");
         return {
-          id: `${match[1]}/${match[2]}`,
+          id: `${org}/${datasetName}`,
           s3_dir: item.s3_dir,
         };
       })


### PR DESCRIPTION
## Summary
- parse dataset names to derive organization and dataset slug

## Testing
- `pytest -k test_available -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852a835641c832a981f4b83a5323006