### PR TITLE
Fix dataset ordering in explore page

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
@@ -64,7 +64,14 @@ export default async function ExplorePage({
         };
       })
       .filter(Boolean) as { id: string; s3_dir: string }[];
-    const allDatasets = [...builderDatasets, ...visualizerDatasets];
+    const allDatasets = [...builderDatasets, ...visualizerDatasets].sort(
+      (a, b) => {
+        const [orgA, nameA = ""] = a.id.split("/");
+        const [orgB, nameB = ""] = b.id.split("/");
+        const orgCompare = orgA.localeCompare(orgB);
+        return orgCompare !== 0 ? orgCompare : nameA.localeCompare(nameB);
+      },
+    );
 
     // Use searchParams from props
     const page = parseInt(searchParams?.p || "1", 10);


### PR DESCRIPTION
## Summary
- sort datasets by organization and name in the explore page

## Testing
- `pre-commit run --files lerobot/html_dataset_visualizer/src/app/explore/page.tsx` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852ac45d78c832ab6e911440b8a283f