### PR TITLE
Fix repoId generation

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -18,7 +18,14 @@ export async function getEpisodeData(
   dataset: string,
   episodeId: number,
 ) {
-  const repoId = `${org}/${dataset}`;
+  const tokens = dataset.split("-");
+  let organization = org;
+  let datasetName = dataset;
+  if (tokens.length > 1) {
+    organization = tokens[0];
+    datasetName = tokens.slice(1).join("-");
+  }
+  const repoId = `${organization}/${datasetName}`;
   const keyPrefix = `data-builder/${org}/data/${dataset}`.replace(/\/$/, "");
 
   const sign = async (key: string) => {

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -9,8 +9,15 @@ export async function generateMetadata({
   params: { org: string; dataset: string; episode: string };
 }) {
   const { org, dataset, episode } = params;
+  const tokens = dataset.split("-");
+  let organization = org;
+  let datasetName = dataset;
+  if (tokens.length > 1) {
+    organization = tokens[0];
+    datasetName = tokens.slice(1).join("-");
+  }
   return {
-    title: `${org}/${dataset} | episode ${episode}`,
+    title: `${organization}/${datasetName} | episode ${episode}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- adjust repoId parsing to fall back to route org when dataset name has no dash

## Testing
- `npm run lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `pytest -k html_dataset_visualizer -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852a835641c832a981f4b83a5323006