### PR TITLE
Fix repoId generation

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -18,7 +18,14 @@ export async function getEpisodeData(
   dataset: string,
   episodeId: number,
 ) {
-  const repoId = `${org}/${dataset}`;
+  let organization = org;
+  let datasetName = dataset;
+  if (/^\d+(\.\d+)*$/.test(org)) {
+    const tokens = dataset.split("-");
+    organization = tokens[0];
+    datasetName = tokens.slice(1).join("-") || tokens[0];
+  }
+  const repoId = `${organization}/${datasetName}`;
   const keyPrefix = `data-builder/${org}/data/${dataset}`.replace(/\/$/, "");
 
   const sign = async (key: string) => {

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/page.tsx
@@ -9,8 +9,15 @@ export async function generateMetadata({
   params: { org: string; dataset: string; episode: string };
 }) {
   const { org, dataset, episode } = params;
+  let organization = org;
+  let datasetName = dataset;
+  if (/^\d+(\.\d+)*$/.test(org)) {
+    const tokens = dataset.split("-");
+    organization = tokens[0];
+    datasetName = tokens.slice(1).join("-") || tokens[0];
+  }
   return {
-    title: `${org}/${dataset} | episode ${episode}`,
+    title: `${organization}/${datasetName} | episode ${episode}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- fix repoId by parsing organization and dataset from dataset name only when `org` looks like a version
- update episode page metadata accordingly

## Testing
- `pytest -k html_dataset_visualizer -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852a835641c832a981f4b83a5323006