### PR TITLE
Fix dataset viewer default episode

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/page.tsx
@@ -5,6 +5,6 @@ export default function DatasetRootPage({
 }: {
   params: { org: string; dataset: string };
 }) {
-  redirect(`/${params.org}/${params.dataset}/episode_1`);
+  redirect(`/${params.org}/${params.dataset}/episode_0`);
   return null;
 }


### PR DESCRIPTION
## Summary
- fix default episode redirect so datasets with only episode 0 display correctly

## Testing
- `pytest -k test_available -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6852c45aa628832aba389fed079c2ead