### PR TITLE
Fix episode chunk selection in HTML visualizer

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -26,10 +26,13 @@ export async function getEpisodeData(
   };
 
   try {
-    const episode_chunk = Math.floor(0 / 1000);
     const jsonUrl = await sign("meta/info.json");
 
     const info = await fetchJson<DatasetMetadata>(jsonUrl);
+
+    const episode_chunk = Math.floor(
+      episodeId / (info.chunks_size ?? 1000),
+    );
 
     // Dataset information
     const datasetInfo = {


### PR DESCRIPTION
## Summary
- compute `episode_chunk` from the episode id when loading data in the HTML dataset visualizer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68539a17f5dc832a8d2571d32c99cdf6