### PR TITLE
Update html dataset visualizer AWS region and bucket

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -22,7 +22,7 @@ export async function getEpisodeData(
   const keyPrefix = `data-builder/${org}/data/${dataset}`.replace(/\/$/, "");
 
   const sign = async (key: string) => {
-    return getSignedUrl("configint", `${keyPrefix}/${key}`);
+    return getSignedUrl("configint-main", `${keyPrefix}/${key}`);
   };
 
   try {

--- a/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/explore/page.tsx
@@ -21,7 +21,7 @@ export default async function ExplorePage({
   let totalPages = 1;
   try {
     // --- Fetch dataset list from DynamoDB (both data-builder and lerobot-visualizer) ---
-    const ddbClient = new DynamoDBClient({ region: "us-east-2" });
+    const ddbClient = new DynamoDBClient({ region: "us-west-2" });
     const docClient = DynamoDBDocumentClient.from(ddbClient);
 
     const scanBuilder = await docClient.send(
@@ -34,7 +34,7 @@ export default async function ExplorePage({
     const builderDatasets = (scanBuilder.Items || []).map(
       (item: { version: string; data_name: string }) => ({
         id: `${item.version}/${item.data_name}`,
-        s3_dir: `configint/data-builder/${item.version}/data/${item.data_name}/`,
+        s3_dir: `configint-main/data-builder/${item.version}/data/${item.data_name}/`,
       }),
     );
 
@@ -48,7 +48,7 @@ export default async function ExplorePage({
     const visualizerDatasets = (scanVisualizer.Items || [])
       .map((item: { s3_dir: string }) => {
         const match = item.s3_dir.match(
-          /^configint\/data-builder\/(.+)\/data\/(.+)\/$/,
+          /^configint-main\/data-builder\/(.+)\/data\/(.+)\/$/,
         );
         if (!match) return null;
         return {
@@ -75,7 +75,7 @@ export default async function ExplorePage({
   }
 
   // Fetch episode 0 data for each dataset
-  const s3Client = new S3Client({ region: "us-east-2" });
+  const s3Client = new S3Client({ region: "us-west-2" });
   const datasetWithVideos = (
     await Promise.all(
       datasets.map(async (ds: { id: string; s3_dir: string }) => {

--- a/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
+++ b/lerobot/html_dataset_visualizer/src/utils/cloudfront.ts
@@ -9,7 +9,7 @@ import { getSignedUrl as s3GetSignedUrl } from "@aws-sdk/s3-request-presigner";
 let cachedKey: string | null = null;
 let s3Client: S3Client | null = null;
 
-async function getPrivateKey(secretName: string, region = "us-east-2") {
+async function getPrivateKey(secretName: string, region = "us-west-2") {
   if (cachedKey) return cachedKey;
   const client = new SecretsManagerClient({ region });
   const command = new GetSecretValueCommand({ SecretId: secretName });
@@ -34,7 +34,7 @@ export async function getSignedUrl(bucket: string, key: string) {
   }
 
   if (!s3Client) {
-    s3Client = new S3Client({ region: "us-east-2" });
+    s3Client = new S3Client({ region: "us-west-2" });
   }
   const command = new GetObjectCommand({ Bucket: bucket, Key: key });
   return s3GetSignedUrl(s3Client, command, { expiresIn: 3600 });

--- a/lerobot/html_dataset_visualizer/test_cloudfront.py
+++ b/lerobot/html_dataset_visualizer/test_cloudfront.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 import os
 import boto3
 
-def get_private_key_from_secrets_manager(secret_name: str, region_name: str = "us-east-2") -> bytes:
+def get_private_key_from_secrets_manager(secret_name: str, region_name: str = "us-west-2") -> bytes:
     client = boto3.client("secretsmanager", region_name=region_name)
     response = client.get_secret_value(SecretId=secret_name)
     return response["SecretString"].encode("utf-8")


### PR DESCRIPTION
## Summary
- update the html dataset visualizer AWS clients to use the us-west-2 region
- point dataset S3 paths and signing helper at the configint-main bucket

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf36bf5ec832aa4691c9d93d0c6be