### PR TITLE
feat: add subtask timeline visualization

### DIFF
--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/episode-viewer.tsx
@@ -8,6 +8,7 @@ import DataRecharts from "@/components/data-recharts";
 import PlaybackBar from "@/components/playback-bar";
 import { TimeProvider, useTime } from "@/context/time-context";
 import Sidebar from "@/components/side-nav";
+import SubtaskTimeline from "@/components/subtask-timeline";
 import Loading from "@/components/loading-component";
 
 export default function EpisodeViewer({
@@ -44,6 +45,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
     episodes,
     episodeLabels,
     tasks,
+    subtaskSegments,
     ignoredColumns,
   } = data;
 
@@ -53,6 +55,21 @@ function EpisodeViewerInner({ data }: { data: any }) {
   const [videosReady, setVideosReady] = useState(!videosInfo.length);
   const [chartsReady, setChartsReady] = useState(false);
   const isLoading = !videosReady || !chartsReady;
+
+  // Dynamic header height tracking
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(176); // default ~pt-44
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setHeaderHeight(entry.contentRect.height + 32); // +32 for padding
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -179,18 +196,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
       />
 
       {/* Fixed header on top of the charts column */}
-      <div className="fixed top-0 left-[calc(50%+7.5rem)] flex flex-col items-start p-4 z-20 text-left">
-        <a
-          href="https://github.com/huggingface/lerobot"
-          target="_blank"
-          className="block"
-        >
-          <img
-            src="https://github.com/huggingface/lerobot/raw/main/media/lerobot-logo-thumbnail.png"
-            alt="LeRobot Logo"
-            className="w-24"
-          />
-        </a>
+      <div ref={headerRef} className="fixed top-0 left-[calc(50%+7.5rem)] right-0 flex flex-col items-start p-4 z-20 text-left bg-slate-950">
         <a
           href={`https://huggingface.co/datasets/${datasetInfo.repoId}`}
           target="_blank"
@@ -202,9 +208,14 @@ function EpisodeViewerInner({ data }: { data: any }) {
           {episodeLabelPath && `: ${episodeLabelPath}`}
         </p>
         {tasks?.length > 0 && (
-          <p className="text-lg mt-2">
-            tasks: <span className="font-mono">{tasks.join(', ')}</span>
+          <p className="text-lg mt-1">
+            task: <span className="font-mono">{tasks.join(', ')}</span>
           </p>
+        )}
+        {subtaskSegments?.length > 0 && (
+          <div className="w-full mt-2 pr-4">
+            <SubtaskTimeline segments={subtaskSegments} duration={data.duration} />
+          </div>
         )}
       </div>
 
@@ -225,7 +236,7 @@ function EpisodeViewerInner({ data }: { data: any }) {
         </div>
 
         {/* Charts column */}
-        <div className="flex w-[50%] flex-col p-4 items-center pt-36 overflow-hidden">
+        <div className="flex w-[50%] flex-col p-4 items-center overflow-hidden" style={{ paddingTop: headerHeight }}>
           <div className="w-full max-w-full flex-1 flex flex-col overflow-hidden">
             <DataRecharts
               data={chartData}

--- a/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
+++ b/lerobot/html_dataset_visualizer/src/app/[org]/[dataset]/[episode]/fetch-data.ts
@@ -7,6 +7,7 @@ import {
 } from "@/utils/parquetUtils";
 import { pick } from "@/utils/pick";
 import { getSignedUrl } from "@/utils/cloudfront";
+import { SubtaskSegment } from "@/types/subtask";
 
 const DATASET_URL =
   process.env.DATASET_URL || "https://huggingface.co/datasets";
@@ -81,6 +82,23 @@ export async function getEpisodeData(
       }
     } catch (err) {
       console.warn("Failed to fetch episodes.jsonl", err);
+    }
+
+    // Fetch subtask metadata
+    const subtasksMap: Record<number, string> = {};
+    try {
+      const subtasksUrl = await sign("meta/subtasks.jsonl");
+      const subtasksText = await (await fetch(subtasksUrl)).text();
+      const subtasksData = subtasksText
+        .split("\n")
+        .filter((line) => line.trim().length)
+        .map((line) => JSON.parse(line));
+      for (const st of subtasksData) {
+        const idx = Number(st.task_index);
+        subtasksMap[idx] = st.task ?? `Subtask ${idx}`;
+      }
+    } catch (err) {
+      console.warn("Failed to fetch subtasks.jsonl (may not exist)", err);
     }
 
     // Videos information
@@ -176,6 +194,44 @@ export async function getEpisodeData(
 
     const duration = chartData[chartData.length - 1].timestamp;
 
+    // Compute subtask segments from parquet low_level_task_index
+    let subtaskSegments: SubtaskSegment[] = [];
+    if (Object.keys(subtasksMap).length > 0) {
+      try {
+        const subtaskFrames = await readParquetColumn(arrayBuffer, [
+          "timestamp",
+          "low_level_task_index",
+        ]);
+        if (subtaskFrames.length > 0) {
+          let currentIndex = Number(subtaskFrames[0][1]);
+          let segmentStart = Number(subtaskFrames[0][0]);
+
+          for (let i = 1; i < subtaskFrames.length; i++) {
+            const frameIndex = Number(subtaskFrames[i][1]);
+            if (frameIndex !== currentIndex) {
+              subtaskSegments.push({
+                subtaskIndex: currentIndex,
+                text: subtasksMap[currentIndex] ?? `Subtask ${currentIndex}`,
+                startTime: segmentStart,
+                endTime: Number(subtaskFrames[i][0]),
+              });
+              currentIndex = frameIndex;
+              segmentStart = Number(subtaskFrames[i][0]);
+            }
+          }
+          // Close the last segment
+          subtaskSegments.push({
+            subtaskIndex: currentIndex,
+            text: subtasksMap[currentIndex] ?? `Subtask ${currentIndex}`,
+            startTime: segmentStart,
+            endTime: duration,
+          });
+        }
+      } catch (err) {
+        console.warn("Failed to read low_level_task_index from parquet", err);
+      }
+    }
+
     return {
       datasetInfo,
       episodeId,
@@ -185,6 +241,7 @@ export async function getEpisodeData(
       episodes,
       episodeLabels: episodesLabels,
       tasks: episodesTasks[episodeId] ?? [],
+      subtaskSegments,
       ignoredColumns,
       duration,
     };

--- a/lerobot/html_dataset_visualizer/src/components/subtask-timeline.tsx
+++ b/lerobot/html_dataset_visualizer/src/components/subtask-timeline.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { useTime } from "../context/time-context";
+import { SubtaskSegment } from "@/types/subtask";
+
+type SubtaskTimelineProps = {
+  segments: SubtaskSegment[];
+  duration: number;
+};
+
+function getSegmentColor(index: number, total: number): string {
+  const hue = (index * 360) / Math.max(total, 1);
+  return `hsl(${hue}, 60%, 35%)`;
+}
+
+function getSegmentActiveColor(index: number, total: number): string {
+  const hue = (index * 360) / Math.max(total, 1);
+  return `hsl(${hue}, 70%, 50%)`;
+}
+
+export default function SubtaskTimeline({
+  segments,
+  duration,
+}: SubtaskTimelineProps) {
+  const { currentTime, setCurrentTime } = useTime();
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [listOpen, setListOpen] = useState(false);
+
+  if (!segments.length || duration <= 0) return null;
+
+  const uniqueCount = new Set(segments.map((s) => s.subtaskIndex)).size;
+
+  const activeSegmentIdx = segments.findIndex(
+    (s) => currentTime >= s.startTime && currentTime < s.endTime,
+  );
+  const effectiveActiveIdx =
+    activeSegmentIdx === -1 ? segments.length - 1 : activeSegmentIdx;
+
+  return (
+    <div className="w-full">
+      {/* Compact bar with index numbers */}
+      <div className="flex w-full rounded overflow-hidden border border-slate-700">
+        {segments.map((segment, idx) => {
+          const widthPct =
+            ((segment.endTime - segment.startTime) / duration) * 100;
+          const isActive = idx === effectiveActiveIdx;
+          const isHovered = idx === hoveredIndex;
+
+          return (
+            <div
+              key={`${segment.subtaskIndex}-${idx}`}
+              className="relative cursor-pointer transition-all duration-150"
+              style={{
+                width: `${widthPct}%`,
+                minWidth: "12px",
+                backgroundColor: isActive
+                  ? getSegmentActiveColor(segment.subtaskIndex, uniqueCount)
+                  : getSegmentColor(segment.subtaskIndex, uniqueCount),
+                opacity: isActive || isHovered ? 1 : 0.7,
+                borderRight:
+                  idx < segments.length - 1
+                    ? "1px solid rgb(51 65 85)"
+                    : "none",
+              }}
+              onClick={() => setCurrentTime(segment.startTime)}
+              onMouseEnter={() => setHoveredIndex(idx)}
+              onMouseLeave={() => setHoveredIndex(null)}
+            >
+              <div
+                className={`py-1 text-xs text-center select-none ${isActive ? "text-white font-bold" : "text-slate-300"}`}
+              >
+                {idx}
+              </div>
+
+              {/* Tooltip on hover */}
+              {isHovered && (
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-slate-800 border border-slate-600 rounded shadow-lg text-xs text-slate-100 whitespace-nowrap z-50 pointer-events-none">
+                  <p className="font-semibold">{segment.text}</p>
+                  <p className="text-slate-400">
+                    {segment.startTime.toFixed(1)}s &ndash;{" "}
+                    {segment.endTime.toFixed(1)}s
+                  </p>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Active subtask text + toggle button */}
+      <div className="flex items-start gap-2 mt-1.5">
+        <button
+          onClick={() => setListOpen((prev) => !prev)}
+          className="text-xs text-slate-400 hover:text-slate-200 border border-slate-600 rounded px-1.5 py-0.5 shrink-0"
+        >
+          {listOpen ? "\u25B2" : "\u25BC"} {segments.length}
+        </button>
+        <p className="text-sm text-slate-200">
+          <span className="text-slate-200">subtask:</span>{" "}
+          <span className="text-orange-400 font-semibold">
+            #{effectiveActiveIdx}
+          </span>{" "}
+          {segments[effectiveActiveIdx]?.text}
+        </p>
+      </div>
+
+      {/* Collapsible subtask list */}
+      {listOpen && (
+        <ul className="mt-1 text-sm max-h-40 overflow-y-auto">
+          {segments.map((segment, idx) => {
+            const isActive = idx === effectiveActiveIdx;
+            return (
+              <li
+                key={`${segment.subtaskIndex}-${idx}`}
+                className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer hover:bg-slate-800 ${isActive ? "bg-slate-800" : ""}`}
+                onClick={() => setCurrentTime(segment.startTime)}
+              >
+                <span
+                  className={`text-xs min-w-[20px] ${isActive ? "text-orange-400 font-bold" : "text-slate-500"}`}
+                >
+                  {isActive && "\u25B6 "}
+                  {idx}.
+                </span>
+                <span
+                  className={`flex-1 truncate ${isActive ? "text-orange-300 font-semibold" : "text-slate-300"}`}
+                >
+                  {segment.text}
+                </span>
+                <span className="text-xs text-slate-500 shrink-0">
+                  {segment.startTime.toFixed(1)}s
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lerobot/html_dataset_visualizer/src/types/subtask.ts
+++ b/lerobot/html_dataset_visualizer/src/types/subtask.ts
@@ -1,0 +1,6 @@
+export type SubtaskSegment = {
+  subtaskIndex: number;
+  text: string;
+  startTime: number;
+  endTime: number;
+};


### PR DESCRIPTION
feat: add subtask timeline visualization

- Fetch subtask metadata from meta/subtasks.jsonl and low_level_task_index from parquet
- Display interactive timeline bar with per-segment seek on click
- Show current active subtask text with collapsible full list
- Dynamic header height to prevent overlap with chart area
- Graceful fallback: datasets without subtasks show only task as before